### PR TITLE
fix(automod): repeated text filter channel exclution

### DIFF
--- a/src/automod/MessageFilter.ts
+++ b/src/automod/MessageFilter.ts
@@ -76,6 +76,11 @@ export default class MessageFilter {
     } 
 
     async filterRepeatedText(msg: Message) {
+		const excluded = this.client.config.props[msg.guild!.id].spam_filter.exclude;
+
+		if (excluded.indexOf(msg.channel!.id) !== -1 || excluded.indexOf((msg.channel! as TextChannel).parent?.id) !== -1)
+			return;
+    
         return await this.filterAlmostSameChars(msg.content) || await this.filterAlmostSameText(msg.content);
     }
 


### PR DESCRIPTION
Added repeated text filter channel exclution support.

BREAKING CHANGE: This will disable repeated text filter in the spam filter excluded channels.

- Is Bugfix? *Yes*
- Related issues: #42 
- Closes: #42 
