### PR TITLE
Update the "What's new in V8" page

### DIFF
--- a/docs/app/(docs)/whats-new-in-v8/page.mdx
+++ b/docs/app/(docs)/whats-new-in-v8/page.mdx
@@ -52,6 +52,6 @@ To update your instance, simply download the [latest release](https://github.com
 You can also use [Git](https://git-scm.com) to update your instance, by running this command:
 
 ```bash
-git pull origin main
+git pull origin 8.x
 ```
 However, this will update your instance to the latest **unstable** version.


### PR DESCRIPTION
noticed that whats new in v8 was outdated, so i made a little change to updating so it says to pull from 8.x, that way they get the latest updates